### PR TITLE
Ability to forward multiple ports and/or using yaml file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -72,3 +72,4 @@ _testmain.go
 *.prof
 
 fwd
+tunnels.yaml

--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,8 @@
 .idea/dictionaries
 .idea/vcs.xml
 .idea/jsLibraryMappings.xml
+.idea/fwd.iml
+.idea/misc.xml
 
 # Sensitive or high-churn files:
 .idea/dataSources.ids
@@ -13,6 +15,7 @@
 .idea/sqlDataSources.xml
 .idea/dynamic.xml
 .idea/uiDesigner.xml
+.idea/modules.xml
 
 # Gradle:
 .idea/gradle.xml
@@ -20,6 +23,8 @@
 
 # Mongo Explorer plugin:
 .idea/mongoSettings.xml
+
+.idea
 
 ## File-based project format:
 *.iws

--- a/README.md
+++ b/README.md
@@ -99,9 +99,10 @@ COMMANDS:
      help, h  Shows a list of commands or help for one command
 
 GLOBAL OPTIONS:
-   --from value, -f value  source HOST:PORT (default: "127.0.0.1:8000") [$FWD_FROM]
+   --from value, -f value  source HOST:PORT [$FWD_FROM]
    --to value, -t value    destination HOST:PORT [$FWD_TO]
    --list, -l              list local addresses
+   --config file, -c file  tunnels config file (YAML format), eg. ./tunnels.yaml
    --udp, -u               enable udp forwarding (tcp by default)
    --help, -h              show help
    --version, -v           print the version

--- a/control.go
+++ b/control.go
@@ -1,0 +1,80 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"github.com/fatih/color"
+	"os"
+	"os/signal"
+	"syscall"
+)
+
+const protocolUDP = "upd"
+const protocolTCP = "tcp"
+
+type Tunnel struct {
+	Addr     string `json:"addr"`
+	Protocol string `json:"protocol"`
+	Source   string `json:"source"`
+}
+
+type Controller struct {
+	ctx     context.Context
+	Tunnels []*Tunnel
+}
+
+func NewController(ctx context.Context, tunnels []*Tunnel) *Controller {
+	ctx, cancel := context.WithCancel(ctx)
+
+	c := &Controller{
+		ctx:     ctx,
+		Tunnels: tunnels,
+	}
+
+	c.handleInterrupt(cancel)
+
+	return c
+}
+
+func (c *Controller) printCtrlC() {
+	color.Set(color.FgYellow)
+	fmt.Println()
+	fmt.Println("<CTRL+C> to exit")
+	fmt.Println()
+	color.Unset()
+}
+
+func (c *Controller) handleInterrupt(cancel context.CancelFunc) {
+	sigs := make(chan os.Signal, 1)
+	signal.Notify(sigs, syscall.SIGINT, syscall.SIGTERM)
+	go func() {
+		sig := <-sigs
+		color.Set(color.FgGreen)
+		fmt.Println("\nExecution stopped by", sig)
+		color.Unset()
+		cancel()
+		os.Exit(0)
+	}()
+}
+
+func (c *Controller) Run() error {
+	for _, tunnel := range c.Tunnels {
+		switch tunnel.Protocol {
+		case protocolTCP:
+			go tcpStart(tunnel.Source, tunnel.Addr)
+		case protocolUDP:
+			go udpStart(tunnel.Source, tunnel.Addr)
+		default:
+			return fmt.Errorf("unsupported protocol '%s'", tunnel.Protocol)
+		}
+	}
+
+	c.printCtrlC()
+
+	for {
+		select {
+		case <-c.ctx.Done():
+			return fmt.Errorf("context ended, exiting")
+		}
+	}
+}

--- a/fwd.go
+++ b/fwd.go
@@ -6,6 +6,7 @@ import (
 	"github.com/fatih/color"
 	"github.com/urfave/cli"
 	"io"
+	"log"
 	"net"
 	"os"
 	"runtime"
@@ -153,6 +154,10 @@ func main() {
 			Name:  "build, b",
 			Usage: "build information",
 		},
+		cli.StringFlag{
+			Name:  "config, c",
+			Usage: "tunnels config file (YAML format), eg. ./tunnels.yaml",
+		},
 	}
 	app.Action = func(c *cli.Context) error {
 		defer color.Unset()
@@ -176,6 +181,21 @@ func main() {
 			cli.ShowAppHelp(c)
 			return nil
 		} else {
+			tunnels := make([]*Tunnel, 0)
+
+			configFile := c.String("config")
+			if configFile != "" {
+				config, err := readConfig(configFile)
+				if err != nil {
+					// just emit warning
+					log.Printf("WARNING: %s", err.Error())
+				}
+
+				if config != nil {
+					tunnels = config.Tunnels
+				}
+			}
+
 			fromSl := c.StringSlice("from")
 			toSl := c.StringSlice("to")
 
@@ -193,7 +213,6 @@ func main() {
 				}
 			}
 
-			tunnels := make([]*Tunnel, 0)
 			for i := 0; i < len(fromSl); i++ {
 				tunnel := Tunnel{
 					Source: fromSl[i],

--- a/go.mod
+++ b/go.mod
@@ -7,4 +7,5 @@ require (
 	github.com/urfave/cli v1.22.2
 	golang.org/x/lint v0.0.0-20200130185559-910be7a94367 // indirect
 	golang.org/x/tools v0.0.0-20200212150539-ea181f53ac56 // indirect
+	gopkg.in/yaml.v2 v2.3.0
 )

--- a/go.sum
+++ b/go.sum
@@ -37,3 +37,5 @@ golang.org/x/tools v0.0.0-20200212150539-ea181f53ac56/go.mod h1:TB2adYChydJhpapK
 golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
+gopkg.in/yaml.v2 v2.3.0 h1:clyUAQHOM3G0M3f5vQj7LuJrETvjVot3Z5el9nffUtU=
+gopkg.in/yaml.v2 v2.3.0/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=

--- a/tunnels.sample.yaml
+++ b/tunnels.sample.yaml
@@ -1,0 +1,7 @@
+tunnels:
+- addr: :53100
+  source: 0.something.remote.io:53
+  protocol: udp
+- addr: :54200
+  source: 0.tcp.eu.ngrok.io:19968
+  protocol: tcp


### PR DESCRIPTION
Hey, this PR addresses to the issue #5 
basically, it's 2 new features

1- ability to set multiple forwarding rules directly in command-line. The options `--from` and `--to` has been changed to array, If their length doesn't match there is some checking implemented so that only `from` can be more that `to`, in that case, we fill `to` until it have same length with its latest value. The only caveat here is the protocol which is a boolean so for all ports the same protocol will be applied. Also, maybe could be a concern, the default value of `from` has been removed

2- ability to read yaml file containing the tunnels config. Below is an example
```yaml
tunnels:
- addr: :53100
  source: 0.something.remote.io:53
  protocol: udp
- addr: :54200
  source: 0.tcp.eu.ngrok.io:19968
  protocol: tcp
```
In this case, it's completely free to set each tunnel configuration which is determined with addr, source and protocol

The rest of the flow has been kept as is
